### PR TITLE
feat: redirect authenticated users from homepage to /dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,21 @@
-import { clerkMiddleware } from '@clerk/nextjs/server'
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
 
-export default clerkMiddleware()
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
+const isHomePage = createRouteMatcher(['/'])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect()
+  }
+
+  if (isHomePage(req)) {
+    const { userId } = await auth()
+    if (userId) {
+      return NextResponse.redirect(new URL('/dashboard', req.url))
+    }
+  }
+})
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Redirects logged-in users visiting `/` to `/dashboard` via Clerk middleware. Also adds route protection for all `/dashboard` routes.

Closes #3

Generated with [Claude Code](https://claude.ai/code)