### PR TITLE
feat: protect /dashboard routes with not-authorized page

### DIFF
--- a/src/app/not-authorized/page.tsx
+++ b/src/app/not-authorized/page.tsx
@@ -1,0 +1,20 @@
+import { SignInButton } from "@clerk/nextjs";
+import { Button } from "@/components/ui/button";
+
+export default function NotAuthorizedPage() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 text-center px-4">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          You must be logged in to access this page
+        </h1>
+        <p className="text-zinc-500 text-sm">
+          Please sign in to continue to the dashboard.
+        </p>
+      </div>
+      <SignInButton mode="modal">
+        <Button>Sign in</Button>
+      </SignInButton>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,10 @@ const isHomePage = createRouteMatcher(['/'])
 
 export default clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
-    await auth.protect()
+    const { userId } = await auth()
+    if (!userId) {
+      return NextResponse.redirect(new URL('/not-authorized', req.url))
+    }
   }
 
   if (isHomePage(req)) {


### PR DESCRIPTION
Closes #5

When an unauthenticated user visits /dashboard or any subpage, they are redirected to a custom /not-authorized page that tells them they need to be logged in, with a sign-in button.

Generated with [Claude Code](https://claude.ai/code)