### PR TITLE
fix: redirect to /dashboard after signing in from not-authorized page

### DIFF
--- a/src/app/not-authorized/page.tsx
+++ b/src/app/not-authorized/page.tsx
@@ -12,7 +12,7 @@ export default function NotAuthorizedPage() {
           Please sign in to continue to the dashboard.
         </p>
       </div>
-      <SignInButton mode="modal">
+      <SignInButton mode="modal" forceRedirectUrl="/dashboard">
         <Button>Sign in</Button>
       </SignInButton>
     </div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 
 const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
 const isHomePage = createRouteMatcher(['/'])
+const isNotAuthorizedPage = createRouteMatcher(['/not-authorized'])
 
 export default clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
@@ -12,7 +13,7 @@ export default clerkMiddleware(async (auth, req) => {
     }
   }
 
-  if (isHomePage(req)) {
+  if (isHomePage(req) || isNotAuthorizedPage(req)) {
     const { userId } = await auth()
     if (userId) {
       return NextResponse.redirect(new URL('/dashboard', req.url))


### PR DESCRIPTION
Fixes #7

- Add `forceRedirectUrl="/dashboard"` to SignInButton so Clerk redirects users to the dashboard after sign-in via the modal
- Update middleware to redirect already-authenticated users away from /not-authorized to /dashboard

Generated with [Claude Code](https://claude.ai/code)