### PR TITLE
feat: update dashboard calendar UI with inline popover date picker

### DIFF
--- a/src/app/dashboard/CalendarClient.tsx
+++ b/src/app/dashboard/CalendarClient.tsx
@@ -1,31 +1,43 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { CalendarIcon } from "lucide-react";
 import { enUS } from "date-fns/locale";
+import { format } from "date-fns";
 
 export function CalendarClient({ selectedDateStr }: { selectedDateStr: string }) {
   const router = useRouter();
+  const [open, setOpen] = useState(false);
   const [y, m, d] = selectedDateStr.split("-").map(Number);
   const selected = new Date(y, m - 1, d);
 
   function handleSelect(date: Date | undefined) {
     if (!date) return;
     const iso = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    setOpen(false);
     router.push(`/dashboard?date=${iso}`);
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="rounded-xl border border-zinc-200 p-4 w-fit">
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="w-fit gap-2">
+          <CalendarIcon className="h-4 w-4" />
+          {format(selected, "PPP")}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
         <Calendar
           mode="single"
           locale={enUS}
           selected={selected}
           onSelect={handleSelect}
         />
-      </div>
-
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -37,73 +37,68 @@ export default async function DashboardPage({
   const selectedDate = new Date(y, m - 1, d);
 
   const workouts = await getWorkoutsForDate(selectedDate);
+  const canLogWorkout = selectedDateStr >= isoToday;
 
   return (
     <div className="flex flex-col gap-8 px-12 py-10 max-w-5xl mx-auto w-full">
       <h1 className="text-3xl font-bold">Workout Dashboard</h1>
 
-      <div className="grid grid-cols-2 gap-10 items-start">
-        {/* Left: Calendar */}
-        <div className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">Select Date</h2>
-          <CalendarClient selectedDateStr={selectedDateStr} />
-        </div>
-
-        {/* Right: Workouts */}
-        <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4">
+        {/* Header row */}
+        <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold">
             Workouts for {formatDate(selectedDate)}
           </h2>
-
-          {workouts.length === 0 ? (
-            <div className="rounded-xl border border-zinc-200 px-5 py-4 flex items-center justify-center min-h-32">
-              <p className="text-base font-bold text-zinc-500 text-center">
-                No workouts logged for this date.
-              </p>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-3">
-              {workouts.map((workout) => (
-                <a
-                  key={workout.id}
-                  href={`/dashboard/workout/${workout.id}`}
-                  className="rounded-xl border border-zinc-200 dark:border-zinc-700 px-5 py-4 flex flex-col gap-3 hover:border-zinc-400 dark:hover:border-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
-                >
-                  <div className="flex items-center justify-between">
-                    <span className="font-bold text-base">{workout.name}</span>
-                    <span className="text-sm text-zinc-500">
-                      {format(workout.startedAt, "h:mm a")}
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {workout.workoutExercises.map((we) => (
-                      <span
-                        key={we.id}
-                        className="rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-2.5 py-0.5 text-xs text-zinc-700 dark:text-zinc-300"
-                      >
-                        {we.exercise.name}
-                      </span>
-                    ))}
-                  </div>
-                  <span className="text-sm text-zinc-500">
-                    Duration: {formatDuration(workout.startedAt, workout.completedAt)}
-                  </span>
-                </a>
-              ))}
-            </div>
-          )}
-
-          {selectedDateStr >= isoToday && (
-            <div className="flex justify-end">
+          <div className="flex items-center gap-3">
+            {canLogWorkout ? (
               <a
                 href={`/dashboard/workout/new?date=${selectedDateStr}`}
-                className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+                className="rounded-lg border border-zinc-300 dark:border-zinc-600 px-4 py-2 text-sm font-medium hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
               >
-                Create workout
+                Log New Workout
               </a>
-            </div>
-          )}
+            ) : (
+              <button
+                disabled
+                className="rounded-lg border border-zinc-200 dark:border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-400 dark:text-zinc-600 cursor-not-allowed"
+              >
+                Log New Workout
+              </button>
+            )}
+            <CalendarClient selectedDateStr={selectedDateStr} />
+          </div>
         </div>
+
+        {/* Workout list */}
+        {workouts.length === 0 ? (
+          <div className="rounded-xl border border-zinc-200 dark:border-zinc-700 px-5 py-4 flex items-center justify-center min-h-32">
+            <p className="text-base font-bold text-zinc-500 text-center">
+              No workouts logged for this date.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {workouts.map((workout) => (
+              <a
+                key={workout.id}
+                href={`/dashboard/workout/${workout.id}`}
+                className="rounded-xl border border-zinc-200 dark:border-zinc-700 px-5 py-4 flex items-center justify-between hover:border-zinc-400 dark:hover:border-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+              >
+                <div className="flex flex-col gap-1">
+                  <span className="font-bold text-base">{workout.name}</span>
+                  <span className="text-sm text-zinc-500">
+                    {workout.completedAt
+                      ? `Completed · Duration: ${formatDuration(workout.startedAt, workout.completedAt)}`
+                      : getWorkoutStatus(workout.startedAt, workout.completedAt)}
+                  </span>
+                </div>
+                <span className="text-sm text-zinc-500">
+                  {format(workout.startedAt, "h:mm a")}
+                </span>
+              </a>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #19

## Summary

- Replaced the full calendar block with a compact Popover date picker triggered by a button showing the formatted selected date
- Reorganized dashboard layout: date picker and \"Log New Workout\" button now sit inline in a header row above the workout list
- Added `canLogWorkout` logic to disable the \"Log New Workout\" button when a past date is selected

## Test plan

- [ ] Open `/dashboard` — verify the date picker button shows today's date
- [ ] Click the button — verify calendar popover opens and closes on date selection
- [ ] Select a past date — verify \"Log New Workout\" button is disabled
- [ ] Select today or a future date — verify \"Log New Workout\" button is enabled and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)